### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://lachgar.visualstudio.com/de426d4e-2f6c-4542-abed-63fd57035dcd/5f3030ed-b289-4c1d-8174-5c70891bc0f2/_apis/work/boardbadge/4fe1fd04-2dbb-48a8-829e-497a27e3011a)](https://lachgar.visualstudio.com/de426d4e-2f6c-4542-abed-63fd57035dcd/_boards/board/t/5f3030ed-b289-4c1d-8174-5c70891bc0f2/Microsoft.RequirementCategory)
 # Blazor-ExchangeApp
 Exchange rate app with Microsoft Blazor technologie


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#59](https://lachgar.visualstudio.com/de426d4e-2f6c-4542-abed-63fd57035dcd/_workitems/edit/59). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.